### PR TITLE
Only needs 2.2 to run.  

### DIFF
--- a/CookieGrailsPlugin.groovy
+++ b/CookieGrailsPlugin.groovy
@@ -17,8 +17,8 @@
 import grails.plugin.cookie.CookieUtils
 
 class CookieGrailsPlugin {
-    def version = '1.1.0'
-    def grailsVersion = '2.4.0 > *'
+    def version = '1.1.1'
+    def grailsVersion = '2.2 > *'
     def author = 'Sergey Ponomarev'
     def authorEmail = 'stokito@gmail.com'
     def title = 'Cookie Plugin'


### PR DESCRIPTION
Thanks for adding so quickly.   The changes you made above make sense.  I noticed that the grails required version was bumped to 2.4 > *.  This is not exactly the case.  I tested this with 2.2.1, 2.3.8 and 2.4.0 and all versions of grails > 2.2 were able to use the plugin.  I reverted the required version back to 2.2 to allow broader use of the plugin.  Thanks!